### PR TITLE
chore: Configure Renovate to bump chart versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,8 @@
   "packageRules": [
     {
       "matchFileNames": ["charts/**/*"],
-      "extends": [":semanticCommitType(fix)"]
+      "extends": [":semanticCommitType(fix)"],
+      "bumpVersion": "patch"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## Description

Updates to chart content require bumping the chart version, otherwise a release cannot be made.

## Additional Context

https://docs.renovatebot.com/configuration-options/#bumpversion

## Checklist

- [X] The chart version in Chart.yaml has been updated according to semantic versioning (semver). This update is not required if the changes only impact README.md files.
- [X] All variables are document in the Chart's values.yaml and README.md files.
- [X] The pull request title meets the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification and includes the chart name, for example: `feat(chart-name): Add replica support`
