### PR TITLE
chore: Use chart name as Renovate scope

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,8 @@
   "packageRules": [
     {
       "matchFileNames": ["charts/**/*"],
-      "extends": [":semanticCommitType(fix)"],
+      "semanticCommitType": "fix",
+      "semanticCommitScope": "{{parentDir}}",
       "bumpVersion": "patch"
     }
   ],


### PR DESCRIPTION
## Description

Refs: https://docs.renovatebot.com/configuration-options/#semanticcommitscope
Refs: https://docs.renovatebot.com/templates/#other-available-fields

## Additional Context

<!-- Add any other context or information about the pull request here. -->

N/A

## Checklist

- [ ] The chart version in Chart.yaml has been updated according to semantic versioning (semver). This update is not required if the changes only impact README.md files.
- [ ] All variables are document in the Chart's values.yaml and README.md files.
- [X] The pull request title meets the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification and includes the chart name, for example: `feat(chart-name): Add replica support`
